### PR TITLE
Use id that includes the feature

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -334,7 +334,7 @@
         "id": null,
         "guid": "d641e1bb-652c-4bb1-a54f-e18b6c1a9746",
         "properties": {},
-        "returns": true
+        "returns": false
       },{
         "why": "Features without any target groups are always off",
         "feature": "feature_flags/malformed/no_target_group.json",

--- a/feature_flags/malformed/missing_identifier.json
+++ b/feature_flags/malformed/missing_identifier.json
@@ -1,5 +1,5 @@
 {
-  "id": "feature_flags/malformed/missing_identifier.json",
+  "id": "feature_1",
   "bucket_type": "guid",
   "target_groups": [
     {

--- a/feature_flags/malformed/missing_identifier.json
+++ b/feature_flags/malformed/missing_identifier.json
@@ -1,9 +1,9 @@
 {
-  "id": "feature_1",
+  "id": "feature_flags/malformed/missing_identifier.json",
   "bucket_type": "guid",
   "target_groups": [
     {
-      "rollout": 1,
+      "rollout": 62000,
       "constraints": {}
     }
   ],


### PR DESCRIPTION
The `missing_identifier` test relies on an Identifier that is included for a rollout of 1, such as `feature_1`.