### PR TITLE
Multiple constraints within target group

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -294,6 +294,16 @@
             "app_version": ["0.2.0"]
         },
         "returns": false
+      },{
+        "why": "When the actor's property array matches all the contraints in a target group",
+        "feature": "feature_flags/target_groups/multiple_constraints.json",
+        "id": "54888",
+        "guid": "d641e1bb-652c-4bb1-a54f-e18b6c1a9746",
+        "properties": {
+            "attribute_1": ["b"],
+            "attribute_2": ["x"]
+        },
+        "returns": true
       }
     ]
   },{

--- a/examples.json
+++ b/examples.json
@@ -295,13 +295,42 @@
         },
         "returns": false
       },{
-        "why": "When the actor's property array matches all the contraints in a target group",
+        "why": "When the actor's property array matches all the constraints in a target group",
         "feature": "feature_flags/target_groups/multiple_constraints.json",
         "id": "54888",
         "guid": "d641e1bb-652c-4bb1-a54f-e18b6c1a9746",
         "properties": {
             "attribute_1": ["b"],
             "attribute_2": ["x"]
+        },
+        "returns": true
+      },{
+        "why": "When the actor's property array partially matches the constraints in a target group",
+        "feature": "feature_flags/target_groups/multiple_constraints.json",
+        "id": "54888",
+        "guid": "d641e1bb-652c-4bb1-a54f-e18b6c1a9746",
+        "properties": {
+          "attribute_1": ["c"]
+        },
+        "returns": false
+      },{
+        "why": "When the actor's property array partially matches the second set of constraints in a target group",
+        "feature": "feature_flags/target_groups/multiple_constraints.json",
+        "id": "54888",
+        "guid": "d641e1bb-652c-4bb1-a54f-e18b6c1a9746",
+        "properties": {
+          "attribute_2": ["x"]
+        },
+        "returns": false
+      },{
+        "why": "When the actor's property array has additional properties but matches all the constraints in a target group",
+        "feature": "feature_flags/target_groups/multiple_constraints.json",
+        "id": "54888",
+        "guid": "d641e1bb-652c-4bb1-a54f-e18b6c1a9746",
+        "properties": {
+          "attribute_1": ["b"],
+          "attribute_2": ["x"],
+          "attribute_3": ["q"]
         },
         "returns": true
       }

--- a/feature_flags/target_groups/multiple_constraints.json
+++ b/feature_flags/target_groups/multiple_constraints.json
@@ -1,0 +1,17 @@
+{
+  "id": "feature_flags/target_groups/multiple_constraints.json",
+  "name": "feature_1",
+  "identifier": "feature_1",
+  "bucket_type": "guid",
+  "target_groups": [
+    {
+      "rollout": 65536,
+      "constraints": {
+        "attribute_1": ["a", "b", "c"],
+        "attribute_2": ["x"]
+      }
+    }
+  ],
+  "active": true,
+  "overrides": {}
+}


### PR DESCRIPTION
## What?
This PR adds the tests for feature flags with multiple constraints in a target group.

## Why?
We didn't even have these tests which cover the different combinations and when relevant logic was updated in `determinator-go` library, we couldn't catch the issue with the logic.

cc: @pedrocunha 