### PR TITLE
Ensure constraints are arrays of strings

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -573,31 +573,23 @@
           "app_version": ["1.3.0"]
         },
         "returns": false
+      },{
+        "why": "Features with constraints which are not arrays of strings should be off, but raise an error",
+        "feature": "feature_flags/malformed/invalid_constraints_number.json",
+        "id": "10321",
+        "guid": "5b189db0-dc19-4b0f-b06e-68e7ffa2e5b8",
+        "properties": {},
+        "returns": false,
+        "error": true
+      },{
+        "why": "Features with constraints which are not arrays of strings should be off, but raise an error",
+        "feature": "feature_flags/malformed/invalid_constraints_scalar.json",
+        "id": "10321",
+        "guid": "5b189db0-dc19-4b0f-b06e-68e7ffa2e5b8",
+        "properties": {},
+        "returns": false,
+        "error": true
       }
     ]
-  },{
-  "section": "Non-string variants",
-  "examples": [
-    {
-      "why": "Numeric variant values should be interpreted as strings",
-      "feature": "experiments/non_string_variants.json",
-      "id": "10321",
-      "guid": "5b189db0-dc19-4b0f-b06e-68e7ffa2e5b8",
-      "properties": {
-        "attribute": ["0"]
-      },
-      "returns": "a"
-    },
-    {
-      "why": "Boolean variant values should be interpreted as strings",
-      "feature": "experiments/non_string_variants.json",
-      "id": "10321",
-      "guid": "5b189db0-dc19-4b0f-b06e-68e7ffa2e5b8",
-      "properties": {
-        "attribute": ["true"]
-      },
-      "returns": "a"
-    }
-  ]
-}
+  }
 ]

--- a/feature_flags/fixed_determinations/high_low_spread_constraints.json
+++ b/feature_flags/fixed_determinations/high_low_spread_constraints.json
@@ -7,12 +7,12 @@
     {
       "feature_on": true,
       "constraints": {
-        "group_a": true
+        "group_a": ["true"]
       }
     },{
       "feature_on": false,
       "constraints":  {
-        "group_b": true
+        "group_b": ["true"]
       }
     }
   ],

--- a/feature_flags/malformed/invalid_constraints_number.json
+++ b/feature_flags/malformed/invalid_constraints_number.json
@@ -1,5 +1,4 @@
 {
-  "id": "experiments/always_assign_to_one_variant.json",
   "name": "feature_1",
   "identifier": "feature_1",
   "bucket_type": "guid",
@@ -7,13 +6,10 @@
     {
       "rollout": 65536,
       "constraints": {
-        "attribute": [0, true]
+        "foo": [1]
       }
     }
   ],
-  "variants": {
-    "a": 1
-  },
   "active": true,
   "overrides": {}
 }

--- a/feature_flags/malformed/invalid_constraints_scalar.json
+++ b/feature_flags/malformed/invalid_constraints_scalar.json
@@ -1,5 +1,4 @@
 {
-  "id": "feature_flags/target_groups/high_low_spread_constraints.json",
   "name": "feature_1",
   "identifier": "feature_1",
   "bucket_type": "guid",
@@ -7,12 +6,7 @@
     {
       "rollout": 65536,
       "constraints": {
-        "group_a": ["true"]
-      }
-    },{
-      "rollout": 1,
-      "constraints":  {
-        "group_b": ["true"]
+        "foo": "bar"
       }
     }
   ],


### PR DESCRIPTION
Non-string constraints are not really supported in actor-tracking, and complicate the client code as it can't assume a fixed schema. This changes the requirement on the clients so that they return an error in this case.

See also https://github.com/deliveroo/actor-tracking/pull/313